### PR TITLE
Rainbond5.1.5 支持 ubuntu16.04离线安装 

### DIFF
--- a/roles/docker/image/tasks/import_pkgs.yml
+++ b/roles/docker/image/tasks/import_pkgs.yml
@@ -6,3 +6,8 @@
   unarchive:
     src: "{{ local_offline }}/rpm.tgz"
     dest: /grdata/services/offline/pkgs/
+    
+- name: Extract deb.tgz into /opt/rainbond/offline/pkgs
+  unarchive:
+    src: "{{ local_offline }}/deb.tgz"
+    dest: /opt/rainbond/offline/pkgs/

--- a/roles/node/exm/tasks/main.yml
+++ b/roles/node/exm/tasks/main.yml
@@ -5,7 +5,11 @@
 
 - name: Rainbond | Install ansible Offline
   shell: "yum install -y sshpass python-pip ansible"
-  when: install_type != "online"
+  when: install_type != "online" and  ansible_distribution == "CentOS"
+
+- name: Rainbond | Install ansible Offline
+  shell: "apt-get -y install sshpass python-pip ansible  --allow-unauthenticated"
+  when: install_type != "online" and  ansible_distribution == "Ubuntu"
 
 - name: Storage | check init 
   stat: path=/tmp/.grdata.share

--- a/roles/prepare/tasks/debian.yml
+++ b/roles/prepare/tasks/debian.yml
@@ -37,6 +37,16 @@
     - https_proxy is defined
     - need_https_proxy.rc != 0
 
+- name: Copy local_rainbond.list into /etc/apt/sources.list.d
+  template:
+    src: /etc/apt/sources.list.d/local_rainbond.list
+    dest: /etc/apt/sources.list.d/local_rainbond.list
+
+- name: Copy repo into /opt/rainbond/offline
+  copy:
+    src: /opt/rainbond/offline/pkgs
+    dest: /opt/rainbond/offline
+
 - name: rm ubuntu lxd & ufw package
   apt: 
     name: 
@@ -53,7 +63,7 @@
 - name: install ubuntu package
   apt: 
     name:
-      - nfs-common          
+      - nfs-common
       - conntrack           
       - jq                  
       - socat               # port forwarding
@@ -63,8 +73,10 @@
       - ipvsadm
       - net-tools
       - expect
+      - docker-ce
     update_cache: yes
     autoclean: yes
+    force: yes
     state: latest
 
 - name: configuration ulimits


### PR DESCRIPTION
1.playbook中debian.yml加入拷贝本节点的离线软件包
2.增加管理节点时缺少判断系统类别，导致节点装软件时不能识别系统，增加了对系统的判断，使用各系统不同的方式装软件
<img width="1442" alt="WeChat1f7b35e6193540fa1006921267f72129" src="https://user-images.githubusercontent.com/50609288/61950890-de160c00-afe1-11e9-87c3-2a4a1ae23139.png">
