### PR TITLE
[FIX] change the way to check / size

### DIFF
--- a/setup.sh
+++ b/setup.sh
@@ -177,7 +177,7 @@ precheck::check_port(){
 
 # Detection of the disk
 precheck::check_disk(){
-    local disk=$(df -h | grep "/$" | awk '{print $2}' | tr 'G' ' ')
+    local disk=$(df -h -B 1g | grep "/$" | awk '{print $2}')
     DISK_LIMIT=30
     DISK_STATUS=$(awk -v num1=$disk -v num2=$DISK_LIMIT 'BEGIN{print(num1>=num2)?"0":"1"}')
     if [ "$DISK_STATUS" == '0' ]; then


### PR DESCRIPTION
当用户拥有TB级乃至PB级的硬盘时，会将数值强制转换为GB，再进行比较