### PR TITLE
update for offline add node

### DIFF
--- a/roles/prepare/tasks/debian.yml
+++ b/roles/prepare/tasks/debian.yml
@@ -38,7 +38,7 @@
     - need_https_proxy.rc != 0
 
 - name: install python-apt offline
-  raw: apt-get install python-apt -y -q --allow-unauthenticated
+  raw: apt-get update && apt-get install python-apt -y -q --allow-unauthenticated
   when: ansible_distribution == "Ubuntu" and install_type == "offline"
 
 - name: rm ubuntu lxd & ufw package

--- a/roles/prepare/tasks/debian.yml
+++ b/roles/prepare/tasks/debian.yml
@@ -37,6 +37,10 @@
     - https_proxy is defined
     - need_https_proxy.rc != 0
 
+- name: install python-apt offline
+  raw: apt-get install python-apt -y -q --allow-unauthenticated
+  when: ansible_distribution == "Ubuntu" and install_type == "offline"
+
 - name: rm ubuntu lxd & ufw package
   apt: 
     name: 


### PR DESCRIPTION
 添加了一个任务，用于在扩容其他节点时安装 python-apt ， 这个包是使用ansible-apt模块的前提。